### PR TITLE
odyssey-x86.coffee: Mark as community device type

### DIFF
--- a/odyssey-x86.coffee
+++ b/odyssey-x86.coffee
@@ -21,9 +21,10 @@ module.exports =
 	version: 1
 	slug: 'odyssey-x86'
 	aliases: [ 'odyssey-x86' ]
-	name: 'Odyssey'
+	name: 'Seeed Odyssey'
 	arch: 'amd64'
 	state: 'new'
+	community: true
 
 	stateInstructions:
 		postProvisioning: postProvisioningInstructions


### PR DESCRIPTION
Also detail a bit the pretty device type name

Changelog-entry: Mark odyssey-x86 as community device type
Signed-off-by: Florin Sarbu <florin@balena.io>