### PR TITLE
Change poky submodule to use our github hosted mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,5 +16,5 @@
 	url = https://github.com/meta-rust/meta-rust
 [submodule "layers/poky"]
 	path = layers/poky
-	url = git://git.yoctoproject.org/poky
+	url = https://github.com/balena-os/poky
 	branch = dunfell


### PR DESCRIPTION
Changelog-entry: Change the poky submodule to our github mirror
Signed-off-by: Florin Sarbu <florin@balena.io>