### PR TITLE
odyssey-x86: Define flasher as default image

### DIFF
--- a/odyssey-x86.coffee
+++ b/odyssey-x86.coffee
@@ -44,10 +44,12 @@ module.exports =
 
 	yocto:
 		machine: 'odyssey-x86'
-		image: 'balena-image'
+		image: 'balena-image-flasher'
 		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'balena-image-odyssey-x86.balenaos-img'
+		deployArtifact: 'balena-image-flasher-odyssey-x86.balenaos-img'
+		deployFlasherArtifact: 'balena-image-flasher-odyssey-x86.balenaos-img'
+		deployRawArtifact: 'balena-image-odyssey-x86.balenaos-img'
 		compressed: true
 
 	configuration:


### PR DESCRIPTION
The odyssey-x86 contains an eMMC so let's default to the flasher image that boots an installer system and programs the raw image into internal storage. This matches the installation instrucitons defined in the device contract which appear in the dashboard when a new device is added.

Also, specify both flasher and raw images as surfacing both in the dashboard is an item in the roadmap.

Changelog-entry: Default to flasher images for the odyssey-x86.
Signed-off-by: Alex Gonzalez <alexg@balena.io>