### PR TITLE
Fix meta-intel submodule url and set kirkstone branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,8 @@
 	branch = master
 [submodule "layers/meta-intel"]
 	path = layers/meta-intel
-	url = git://git.yoctoproject.org/meta-intel
+	url = https://git.yoctoproject.org/git/meta-intel
+	branch = kirkstone
 [submodule "layers/meta-openembedded"]
 	path = layers/meta-openembedded
 	url = https://github.com/openembedded/meta-openembedded


### PR DESCRIPTION
git://git.yoctoproject.org is behind Cloudflare now, which doesn't serve the git protocol on port 9418, so the meta-intel submodule clone hangs until it times out. That's ~9 min of dead wait every renovate run, and it's what tipped the org-wide renovate job past the 1h GitHub App token expiry.

Switched to the https url (verified reachable). The pinned commit dates back to board bring-up and lives on kirkstone, so I set that branch too since it was the only layer without one. Renovate will track kirkstone for this layer from now on.

See: https://balena.fibery.io/Work/Project/Prevent-renovate-run-1h-timeouts-1945
